### PR TITLE
Remove invalid pod example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,6 @@ spec:
     command: ["sleep", "1h"]
 ```
 
-Finally, this Pod specification has a top level security
-context that leads to the creation of a privileged container:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx
-spec:
-  securityContext:
-      privileged: true
-  containers:
-  - name: nginx
-    image: nginx
-    imagePullPolicy: IfNotPresent
-```
-
 
 # Configuration
 


### PR DESCRIPTION
The `securityContext` attribute of Pods does not support a `privileged`
field[1]. Only the container-specific security context supports such an
attribute[2]. Attempting to follow the example causes a schema
validation error unrelated to the admission policy:

  ValidationError(Pod.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext

This change removes the invalid example.

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
[2] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core